### PR TITLE
added asterisk next to title in form .refs #6889

### DIFF
--- a/app/views/custom_attributes/double_values/_edit_double_value.html.erb
+++ b/app/views/custom_attributes/double_values/_edit_double_value.html.erb
@@ -4,7 +4,9 @@
 <% if form %>
 <% # BEGIN Field part of form %>
   <%= form.fields_for :custom_attributes do |custom_fields| %>
-    <%= custom_fields.label double_value.name, class: "#{cssClasses[:title]}" %>
+    <% label_text = double_value.name %>
+    <% label_text += content_tag(:span, '*', class: cssClasses[:required]) if required %>
+    <%= custom_fields.label double_value.name.to_sym, label_text.html_safe, class: cssClasses[:title] %>
     <%= custom_fields.text_field "#{double_value.name}".to_sym, value: "#{double_value.value}", class: "#{cssClasses[:field]}", required: required %>
   <% end %>
 <% # END Field part of form %>

--- a/app/views/custom_attributes/string_values/_edit_string_value.html.erb
+++ b/app/views/custom_attributes/string_values/_edit_string_value.html.erb
@@ -4,7 +4,9 @@
 <% if form %>
 <% # BEGIN Field part of form %>
   <%= form.fields_for :custom_attributes do |custom_fields| %>
-    <%= custom_fields.label string_value.name, class: "#{cssClasses[:title]}" %>
+    <% label_text = string_value.name %>
+    <% label_text += content_tag(:span, '*', class: cssClasses[:required]) if required %>
+    <%= custom_fields.label string_value.name.to_sym, label_text.html_safe, class: cssClasses[:title] %>
     <% if string_value.custom_attribute_defn.attr_type == CustomAttributes::CustomAttribute::TYPE_MULTILINE_TEXT %>
       <%= custom_fields.text_area "#{string_value.name}".to_sym, value: "#{string_value.value}", class: "#{cssClasses[:field]}", required:required %>
     <% else %>

--- a/lib/custom_attributes/version.rb
+++ b/lib/custom_attributes/version.rb
@@ -1,3 +1,3 @@
 module CustomAttributes
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end


### PR DESCRIPTION
 Capitalization is now carried over to print-out and asterisks are shown next to mandatory custom fields.

http://pm.7vals.com/issues/6889