### PR TITLE
Hotfix/35926 Double Value Conversion Issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    custom_attributes_scaffold (0.1.50)
+    custom_attributes_scaffold (0.1.51)
       rails (~> 6.1.0)
 
 GEM

--- a/app/models/custom_attributes/double_value.rb
+++ b/app/models/custom_attributes/double_value.rb
@@ -2,7 +2,7 @@ module CustomAttributes
   module DoubleValue
     def value=(newVal)
       if (newVal && newVal.present?)
-        self.double_value = newVal.to_f
+        self.double_value = newVal.to_d
       else
         self.double_value = nil
       end

--- a/lib/custom_attributes/version.rb
+++ b/lib/custom_attributes/version.rb
@@ -1,3 +1,3 @@
 module CustomAttributes
-  VERSION = '0.1.50'
+  VERSION = '0.1.51'
 end


### PR DESCRIPTION
### Description
Replaced `newVal.to_f` with `newVal.to_d` to prevent inaccuracies when handling large numeric values. The use of `.to_f` could introduce small precision errors due to floating-point representation, where values like `4600000` might be stored as `4600000.000000001`. By converting to `BigDecimal` with `.to_d`, values are stored exactly, maintaining full precision and eliminating potential inaccuracies.


[EZO: Unable to change the value in a cart custom field
](https://pm.7vals.com/issues/35926)

